### PR TITLE
Fixed probrem with Safari

### DIFF
--- a/front/src/js/app.ts
+++ b/front/src/js/app.ts
@@ -55,7 +55,7 @@ function dispLevelMeter(stream: MediaStream) {
     const canvasContext = canvas.getContext("2d") as CanvasRenderingContext2D;
     const volumeElement = document.getElementById("volume") as HTMLElement;
     const fpsElement = document.getElementById("fps") as HTMLElement;
-    const ctx = new AudioContext();
+    const ctx = new ((<any>window).AudioContext || (<any>window).webkitAudioContext)();
     const meter = createAudioMeter(ctx);
     const streamNode = ctx.createMediaStreamSource(stream);
     streamNode.connect(meter);


### PR DESCRIPTION
#6 に対応。
WebKitの場合はAudioContextの生成方法が違っていた。